### PR TITLE
Initial support for running local and remote kernels side by side.

### DIFF
--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -16,7 +16,7 @@ from traitlets import Bool, Instance, Int
 
 from ..services.kernels.connection.base import BaseKernelWebsocketConnection
 from ..utils import url_path_join
-from .managers import GatewayClient
+from .gateway_client import GatewayClient
 
 
 class GatewayWebSocketConnection(BaseKernelWebsocketConnection):

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -95,6 +95,25 @@ class GatewayClient(SingletonConfigurable):
     helper methods to build request arguments out of the various config
     """
 
+    enable_local_kernels_default_value = False
+    enable_local_kernels_env = "JUPYTER_GATEWAY_ENABLE_LOCAL_KERNELS"
+    enable_local_kernels = Bool(
+        default_value=enable_local_kernels_default_value,
+        config=True,
+        help="""If enabled, then gateway kernels augment, rather than replace local kernels.
+        (JUPYTER_GATEWAY_ENABLE_LOCAL_KERNELS env var)
+        """,
+    )
+
+    @default("enable_local_kernels")
+    def _enable_local_kernels_default(self):
+        return bool(
+            os.environ.get(
+                self.enable_local_kernels_env, str(self.enable_local_kernels_default_value).lower()
+            )
+            not in ["no", "false"]
+        )
+
     event_schema_id = JUPYTER_SERVER_EVENTS_URI + "/gateway_client/v1"
     event_logger = Instance(EventLogger).tag(config=True)
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -92,6 +92,7 @@ from jupyter_server.gateway.managers import (
     GatewayClient,
     GatewayKernelSpecManager,
     GatewayMappingKernelManager,
+    GatewayRoutingMappingKernelManager,
     GatewaySessionManager,
 )
 from jupyter_server.log import log_request
@@ -107,6 +108,10 @@ from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebso
 from jupyter_server.services.kernels.kernelmanager import (
     AsyncMappingKernelManager,
     MappingKernelManager,
+)
+from jupyter_server.services.kernels.routing import (
+    RoutingKernelManager,
+    RoutingKernelSpecManager,
 )
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 from jupyter_server.utils import (
@@ -778,6 +783,8 @@ class ServerApp(JupyterApp):
         MappingKernelManager,
         KernelSpecManager,
         AsyncMappingKernelManager,
+        RoutingKernelSpecManager,
+        RoutingKernelManager,
         ContentsManager,
         FileContentsManager,
         AsyncContentsManager,
@@ -788,6 +795,7 @@ class ServerApp(JupyterApp):
         GatewaySessionManager,
         GatewayWebSocketConnection,
         GatewayClient,
+        GatewayRoutingMappingKernelManager,
         Authorizer,
         EventLogger,
         ZMQChannelsWebsocketConnection,
@@ -1481,7 +1489,10 @@ class ServerApp(JupyterApp):
     @default("kernel_manager_class")
     def _default_kernel_manager_class(self):
         if self.gateway_config.gateway_enabled:
-            return "jupyter_server.gateway.managers.GatewayMappingKernelManager"
+            if self.gateway_config.enable_local_kernels:
+                return "jupyter_server.gateway.managers.GatewayRoutingMappingKernelManager"
+            else:
+                return "jupyter_server.gateway.managers.GatewayMappingKernelManager"
         return AsyncMappingKernelManager
 
     session_manager_class = Type(
@@ -1491,7 +1502,7 @@ class ServerApp(JupyterApp):
 
     @default("session_manager_class")
     def _default_session_manager_class(self):
-        if self.gateway_config.gateway_enabled:
+        if self.gateway_config.gateway_enabled and not self.gateway_config.enable_local_kernels:
             return "jupyter_server.gateway.managers.GatewaySessionManager"
         return SessionManager
 
@@ -1529,7 +1540,10 @@ class ServerApp(JupyterApp):
     @default("kernel_spec_manager_class")
     def _default_kernel_spec_manager_class(self):
         if self.gateway_config.gateway_enabled:
-            return "jupyter_server.gateway.managers.GatewayKernelSpecManager"
+            if self.gateway_config.enable_local_kernels:
+                return "jupyter_server.services.kernels.routing.RoutingKernelSpecManager"
+            else:
+                return "jupyter_server.gateway.managers.GatewayKernelSpecManager"
         return KernelSpecManager
 
     login_handler_class = Type(

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -37,6 +37,7 @@ from traitlets import (
     Integer,
     List,
     TraitError,
+    Type,
     Unicode,
     default,
     observe,
@@ -49,6 +50,8 @@ from jupyter_server.prometheus.metrics import KERNEL_CURRENTLY_RUNNING_TOTAL
 from jupyter_server.utils import ApiPath, import_item, to_os_path
 
 from ..kernelspecs.renaming import normalize_kernel_name
+from .connection.base import BaseKernelWebsocketConnection
+from .connection.channels import ZMQChannelsWebsocketConnection
 
 
 class MappingKernelManager(MultiKernelManager):
@@ -861,6 +864,14 @@ class ServerKernelManager(AsyncIOLoopKernelManager):
     ).tag(config=True)
 
     event_logger = Instance(EventLogger)
+
+    websocket_connection_class = Type(
+        default_value=ZMQChannelsWebsocketConnection,
+        klass=BaseKernelWebsocketConnection,
+        help="""
+        The websocket connection class to use for this manager's kernels.
+        """,
+    ).tag(config=True)
 
     @default("event_logger")
     def _default_event_logger(self):

--- a/jupyter_server/services/kernels/routing.py
+++ b/jupyter_server/services/kernels/routing.py
@@ -1,0 +1,190 @@
+import typing as t
+
+from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client.manager import in_pending_state
+from jupyter_client.managerabc import KernelManagerABC
+from jupyter_core.utils import ensure_async, run_sync
+from traitlets import (
+    Dict,
+    Instance,
+    List,
+    Unicode,
+)
+
+from .connection.base import BaseKernelWebsocketConnection
+from .connection.channels import ZMQChannelsWebsocketConnection
+from .kernelmanager import AsyncMappingKernelManager, ServerKernelManager
+
+
+class AsyncRoutingKernelSpecManager(KernelSpecManager):
+    """KernelSpecManager that routes to multiple nested kernel spec managers.
+
+    This async version of the wrapper exists because the base KernelSpecManager
+    class only has synchronous methods, but some child classes (in particular,
+    GatewayKernelManager) change those methods to be async.
+
+    In order to support both versions, we first implement the routing in this async
+    class, but then make it synchronous in the child, RoutingKernelSpecManager class.
+    """
+
+    default_manager = Instance(AsyncMappingKernelManager)
+
+    additional_managers = List(trait=Instance(AsyncMappingKernelManager))
+
+    spec_to_manager_map = Dict(key_trait=Unicode(), value_trait=Instance(AsyncMappingKernelManager))
+
+    async def get_all_specs(self):
+        ks = await ensure_async(self.default_manager.kernel_spec_manager.get_all_specs())
+        for spec_name, _spec in ks.items():
+            self.spec_to_manager_map[spec_name] = self.default_manager
+        for additional_manager in self.additional_managers:
+            additional_ks = await ensure_async(
+                additional_manager.kernel_spec_manager.get_all_specs()
+            )
+            for spec_name, spec in additional_ks.items():
+                if spec_name not in ks:
+                    ks[spec_name] = spec
+                    self.spec_to_manager_map[spec_name] = additional_manager
+        return ks
+
+    def get_mapping_kernel_manager(self, kernel_name: str) -> AsyncMappingKernelManager:
+        km = self.spec_to_manager_map.get(kernel_name, None)
+        if km is None:
+            return self.default_manager
+        return km
+
+    def get_mapping_kernel_manager_for_kernel(self, kernel_id: str) -> AsyncMappingKernelManager:
+        if kernel_id in self.default_manager.list_kernels():
+            return self.default_manager
+        for manager in self.additional_managers:
+            if kernel_id in manager.list_kernels():
+                return manager
+        return self.default_manager
+
+    async def get_kernel_spec(self, kernel_name, **kwargs):
+        wrapped_manager = self.get_mapping_kernel_manager(kernel_name).kernel_spec_manager
+        return ensure_async(wrapped_manager.get_kernel_spec(kernel_name, **kwargs))
+
+    async def get_kernel_spec_resource(self, kernel_name, path):
+        wrapped_manager = self.get_mapping_kernel_manager(kernel_name)
+        wrapped_kernelspec_manager = wrapped_manager.kernel_spec_manager
+        self.log.debug(
+            "Getting kernel spec resource for {} from {}/{}".format(
+                kernel_name, wrapped_manager, wrapped_kernelspec_manager
+            )
+        )
+        if hasattr(wrapped_kernelspec_manager, "get_kernel_spec_resource"):
+            return await ensure_async(
+                wrapped_kernelspec_manager.get_kernel_spec_resource(kernel_name, path)
+            )
+        return None
+
+
+class RoutingKernelSpecManager(AsyncRoutingKernelSpecManager):
+    """KernelSpecManager that routes to multiple nested kernel spec managers."""
+
+    def get_all_specs(self):
+        return run_sync(super().get_all_specs)()
+
+    def get_kernel_spec(self, kernel_name, *args, **kwargs):
+        return run_sync(super().get_kernel_spec)(kernel_name, *args, **kwargs)
+
+
+class RoutingKernelManagerWebsocketConnection(BaseKernelWebsocketConnection):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        km = self.kernel_manager.wrapped_kernel_manager
+        wrapped_class = ZMQChannelsWebsocketConnection
+        if hasattr(km, "websocket_connection_class"):
+            wrapped_class = km.websocket_connection_class
+        self.wrapped = wrapped_class(
+            parent=km, websocket_handler=self.websocket_handler, config=self.config
+        )
+
+    async def connect(self):
+        """Connect the kernel websocket to the kernel ZMQ connections"""
+        return await self.wrapped.connect()
+
+    async def disconnect(self):
+        """Disconnect the kernel websocket from the kernel ZMQ connections"""
+        return await self.wrapped.disconnect()
+
+    def handle_incoming_message(self, incoming_msg: str) -> None:
+        """Broker the incoming websocket message to the appropriate ZMQ channel."""
+        self.wrapped.handle_incoming_message(incoming_msg)
+
+    def handle_outgoing_message(self, stream: str, outgoing_msg: list) -> None:
+        """Broker outgoing ZMQ messages to the kernel websocket."""
+        self.wrapped.handle_outgoing_message(stream, outgoing_msg)
+
+    async def prepare(self):
+        if hasattr(self.wrapped, "prepare"):
+            self.wrapped.prepare()
+        self.session = self.wrapped.session
+        self.session.key = self.wrapped.kernel_manager.session.key
+
+
+class RoutingKernelManager(ServerKernelManager):
+    kernel_id_map: t.Dict[str, str] = {}
+
+    @property
+    def wrapped_multi_kernel_manager(self):
+        return self.parent.kernel_spec_manager.get_mapping_kernel_manager(self.kernel_name)
+
+    @property
+    def wrapped_kernel_manager(self):
+        if not self.kernel_id:
+            return None
+        wrapped_kernel_id = RoutingKernelManager.kernel_id_map.get(self.kernel_id, self.kernel_id)
+        return self.wrapped_multi_kernel_manager.get_kernel(wrapped_kernel_id)
+
+    @property
+    def websocket_connection_class(self):
+        return RoutingKernelManagerWebsocketConnection
+
+    @property
+    def has_kernel(self):
+        if not self.kernel_id:
+            return False
+        return self.wrapped_kernel_manager.has_kernel
+
+    def client(self, *args, **kwargs):
+        if not self.kernel_id:
+            return None
+        return self.wrapped_kernel_manager.client(*args, **kwargs)
+
+    @in_pending_state
+    async def start_kernel(self, *args, **kwargs):
+        kernel_id: t.Optional[str] = kwargs.pop("kernel_id", self.kernel_id)
+        if kernel_id:
+            self.kernel_id = kernel_id
+
+        km = self.wrapped_multi_kernel_manager
+        wrapped_kernel_id: str = await ensure_async(
+            km.start_kernel(kernel_name=self.kernel_name, **kwargs)
+        )
+        self.kernel_id = self.kernel_id or wrapped_kernel_id
+        RoutingKernelManager.kernel_id_map[self.kernel_id] = wrapped_kernel_id
+        self.log.debug(
+            f"Created kernel {self.kernel_id} corresponding to {wrapped_kernel_id} in {km}"
+        )
+        self.log.debug(RoutingKernelManager.kernel_id_map)
+
+    async def shutdown_kernel(self, now=False, restart=False):
+        wrapped_kernel_id = RoutingKernelManager.kernel_id_map.get(self.kernel_id, self.kernel_id)
+        km = self.wrapped_multi_kernel_manager
+        await ensure_async(km.shutdown_kernel(wrapped_kernel_id, now=now, restart=restart))
+        RoutingKernelManager.kernel_id_map.pop(self.kernel_id, None)
+
+    async def restart_kernel(self, now=False):
+        wrapped_kernel_id = RoutingKernelManager.kernel_id_map.get(self.kernel_id, self.kernel_id)
+        km = self.wrapped_multi_kernel_manager
+        return await ensure_async(km.restart_kernel(wrapped_kernel_id, now=now))
+
+    async def interrupt_kernel(self):
+        wrapped_kernel_id = RoutingKernelManager.kernel_id_map.get(self.kernel_id, self.kernel_id)
+        km = self.wrapped_kernel_manager
+        return await ensure_async(km.interrupt_kernel(wrapped_kernel_id))
+
+
+KernelManagerABC.register(RoutingKernelManager)

--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -19,6 +19,10 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler): 
     @property
     def kernel_websocket_connection_class(self):
         """The kernel websocket connection class."""
+        if self.kernel_manager and self.kernel_id:
+            kernel = self.kernel_manager.get_kernel(self.kernel_id)
+            if hasattr(kernel, "websocket_connection_class"):
+                return kernel.websocket_connection_class
         return self.settings.get("kernel_websocket_connection_class")
 
     def set_default_headers(self):


### PR DESCRIPTION
This change adds a new type of KernelSpecManager and corresponding KernelManager that wrap one or more nested MultiKernelManagers and route requests to the appropriate one based on kernel spec.